### PR TITLE
Add quotes to avoid wildcard  expansion errors zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Laravel 5 wrapper for calcinai/xero-php (a custom API for integrating with Xer
 
 **Require the package**
 
-    composer require drawmyattention/xerolaravel 1.0.*
+    composer require drawmyattention/xerolaravel "1.0.*"
     
 **Publish the configuration file**
 


### PR DESCRIPTION
Shell such as ZSH will see asterisk symbols as a wildcard and instead of running the command will return the following error:

> composer require drawmyattention/xerolaravel 1.0.*
> zsh: no matches found: 1.0.*

Adding quotes fixes this
