### PR TITLE
Add fascades for Account and Payment

### DIFF
--- a/Facades/XeroAccount.php
+++ b/Facades/XeroAccount.php
@@ -1,0 +1,9 @@
+<?php
+namespace DrawMyAttention\XeroLaravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class XeroAccount extends Facade
+{
+    protected static function getFacadeAccessor() { return 'XeroAccount'; }
+}

--- a/Facades/XeroPayment.php
+++ b/Facades/XeroPayment.php
@@ -1,0 +1,9 @@
+<?php
+namespace DrawMyAttention\XeroLaravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class XeroPayment extends Facade
+{
+    protected static function getFacadeAccessor() { return 'XeroPayment'; }
+}

--- a/Providers/XeroServiceProvider.php
+++ b/Providers/XeroServiceProvider.php
@@ -47,12 +47,20 @@ class XeroServiceProvider extends ServiceProvider
            return new \XeroPHP\Models\Accounting\Invoice();
         });
 
+        $this->app->bind('XeroPayment', function(){
+           return new \XeroPHP\Models\Accounting\Payment();
+        });
+
         $this->app->bind('XeroInvoiceLine', function(){
             return new \XeroPHP\Models\Accounting\Invoice\LineItem();
         });
 
         $this->app->bind('XeroContact', function(){
             return new \XeroPHP\Models\Accounting\Contact();
+        });
+
+        $this->app->bind('XeroAccount', function(){
+            return new \XeroPHP\Models\Accounting\Account();
         });
 
         $this->app->bind('XeroBrandingTheme', function(){


### PR DESCRIPTION
I had a situation where I wanted to add a payment to an invoice and couldn't do it with your current version. I've added fascades for account and payment now so that you can now do the following:

```
$account = $this->app->make('XeroAccount');
$account->setAccountID('ACCOUNTID');

$payment = $this->app->make('XeroPayment');
$payment->setInvoice($invoice);
$payment->setAccount($account);
$payment->setAmount(99.99);
$xero->save($payment);
```
